### PR TITLE
Include current file in error messages

### DIFF
--- a/lib/gulp-polymer-rename-extract.js
+++ b/lib/gulp-polymer-rename-extract.js
@@ -59,6 +59,8 @@ class PolymerRenamerStream extends stream.Transform {
       excludedPaths: this._opts.excludedPaths
     };
 
+    let currentFile;
+
     parseElements(opts, ...this._files)
         .then(results => {
           results.warnings.forEach(warning => {
@@ -71,6 +73,7 @@ class PolymerRenamerStream extends stream.Transform {
             const features = featureInfo.renameExpressions.sort((a, b) => b.start - a.start);
             const originalFileIndex = this._files.findIndex(file => file.path === normalizedFileUrl);
             const originalFile = this._files[originalFileIndex];
+            currentFile = originalFile.path;
             let originalFileWorkingContents = originalFile.contents.toString();
             let newFileContent = [];
             features.forEach(replacement => {
@@ -103,12 +106,16 @@ class PolymerRenamerStream extends stream.Transform {
             newFile.contents = Buffer.from(`${newFileContent.join('')}\n${templateCreator}\n${featureInfo.output}`, 'utf8');
             this._files[originalFileIndex] = newFile;
           });
-          this._files.forEach(file => this.push(file));
+          this._files.forEach(file => {
+            currentFile = file.path;
+            this.push(file)
+          });
 
           cb();
         })
         .catch(err => {
-          cb(new gutil.PluginError('polymer-rename', err.message, {showStack: true}));
+          const errMessage = `${currentFile} - ${err.message}`;
+          cb(new gutil.PluginError('polymer-rename', errMessage, {showStack: true}));
         });
   }
 }


### PR DESCRIPTION
## Summary
This simply adds a variable to track the current file being processed and includes it in the error message. This is necessary because `esprima` does not include the file path in its error message.