### PR TITLE
Handle property type annotations in constructor

### DIFF
--- a/lib/extract-expressions/polymer-template-expressions.js
+++ b/lib/extract-expressions/polymer-template-expressions.js
@@ -185,8 +185,8 @@ class PolymerTemplateExpressions {
           domRepeatItemsExpression = propArrayExpression;
         }
         isRenameable = false;
-      } else if (property.astNode && property.astNode.node && property.astNode.node.key) {
-        isRenameable = property.astNode.node.key.type === 'Identifier';
+      } else if (property.astNode && property.astNode.node) {
+        isRenameable = (property.astNode.node.key || property.astNode.node.property).type === 'Identifier';
       }
 
       return {
@@ -1091,7 +1091,9 @@ class PolymerTemplateExpressions {
 
     if (this.elementProperties.has(tagName)) {
       const propInfo = this.elementProperties.get(tagName).properties.get(propName);
-      if (propInfo && propInfo.astNode.node.key.type === 'Identifier') {
+      // either a reactive property or standard class property
+      if (propInfo && propInfo.astNode && propInfo.astNode.node &&
+          (propInfo.astNode.node.key || propInfo.astNode.node.property).type === 'Identifier') {
         return true;
       }
     }


### PR DESCRIPTION
## Summary

It is possible to set a property's initial value in the constructor, in which case you may want to add a type annotation. Currently, `polymer-rename` chokes on that with a `Cannot read property 'type' of undefined` error. This fixes that so type annotations for reactive properties can be specified in the component's constructor as opposed to the class `properties` getter, like how Lit default property values are set.

## How to test
1. Set a reactive property's default value in the constructor and add a type annotation for the property
2. Execute the "extract" phase of polymer-rename
   - You should not see any errors