### PR TITLE
Fix Codeowners syntax

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@banno/team-online
+* @banno/team-online


### PR DESCRIPTION
The path is required.  It works similarly to a .gitignore file.