### PR TITLE
fix handling of polymer bindings that have been split into multiple lines

### DIFF
--- a/lib/extract-expressions/polymer-template-expressions.js
+++ b/lib/extract-expressions/polymer-template-expressions.js
@@ -1057,6 +1057,14 @@ class PolymerTemplateExpressions {
     startIndex += dataBindingMatches.index + dataBindingMatches[0].length;
     let value = contentWithExpression.substring(dataBindingMatches.index + dataBindingMatches[0].length, dataBindingExprEndIndex);
 
+    // databinding expressions can be split onto multiple lines.
+    // collapse into one line
+    const newLines = /\n */m.exec(value);
+    if (newLines !== null) {
+      endIndex -= (newLines[0].length - 1);// subtract one, we replace the newline and following spaces with a single space
+      value = value.replace(/\n */m, ' ');
+    }
+
     let whitespaceMatches = /\s*$/.exec(value);
     if (whitespaceMatches !== null) {
       value = value.trim();
@@ -1069,6 +1077,7 @@ class PolymerTemplateExpressions {
       endIndex -= value.length - eventExprIndex;
       value = value.substring(0, eventExprIndex);
     }
+
 
     return {
       value,


### PR DESCRIPTION
code formatting tools like prettier can split a polymer binding into multiple lines. This adds handling to parse those bindings correctly.