### PR TITLE
Prevent renaming of lit-element properties that have "attribute" defs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "extends": "google",
   "parserOptions": {
-    "ecmaVersion": 6,
+    "ecmaVersion": 2023,
     "sourceType": "module"
   },
   "rules": {

--- a/lib/extract-expressions/polymer-template-expressions.js
+++ b/lib/extract-expressions/polymer-template-expressions.js
@@ -1091,6 +1091,15 @@ class PolymerTemplateExpressions {
 
     if (this.elementProperties.has(tagName)) {
       const propInfo = this.elementProperties.get(tagName).properties.get(propName);
+
+      // Look for lit-element defined attribute string
+      const propAttributeDef = propInfo?.astNode?.node?.value?.properties?.find(
+          (prop) => prop.key?.type === 'Identifier' && prop.key?.name === 'attribute',
+      );
+      if (propAttributeDef?.value?.type === 'StringLiteral') {
+        return false;
+      }
+
       // either a reactive property or standard class property
       if (propInfo && propInfo.astNode && propInfo.astNode.node &&
           (propInfo.astNode.node.key || propInfo.astNode.node.property).type === 'Identifier') {


### PR DESCRIPTION
When a lit-element has a property with an attribute definition:

```js
class MyElement extends LitElement {
  static get properties() {
    return {
      myProp: {
        type: Boolean,
        attribute: 'my-prop',
      }
    }
  }
}
```

Prevent polymer-rename from renaming that property at the use site:

```html
<my-element my-prop></my-element>
```